### PR TITLE
feat: add SaaS support with Bearer token auth and API v1 endpoints

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,9 +1,29 @@
+# ============================================
+# Shioaji Trading Backend 環境設定
+# ============================================
+
 # Shioaji API Credentials (from SinoPac Securities)
 API_KEY=your_shioaji_api_key_here
 SECRET_KEY=your_shioaji_secret_key_here
 
-# Dashboard Authentication Key (set your own secure password)
+# Dashboard Authentication Key (舊版，保持向下相容)
 AUTH_KEY=your_secure_auth_key_here
+
+# ============================================
+# SaaS 連線設定（新增）
+# ============================================
+
+# 後端 API Token（供 SaaS 前端連線使用）
+# 設定後可使用 Authorization: Bearer <token> 認證
+BACKEND_API_TOKEN=your_backend_api_token_here
+
+# CORS 允許的來源（逗號分隔）
+# 設定 SaaS 前端的 URL，允許跨域請求
+ALLOWED_ORIGINS=https://dashboard.your-saas.com,http://localhost:5173
+
+# ============================================
+# 交易設定
+# ============================================
 
 # Supported Futures Products (comma-separated, optional)
 # Common options: MXF (小台), TXF (大台), EXF (電子期), FXF (金融期), etc.


### PR DESCRIPTION
## Summary

新增 SaaS 前端連線支援，讓用戶可以透過遠端 SaaS 儀表板控制自建的交易後端。

### 功能
- 新增 `BACKEND_API_TOKEN` 環境變數，支援 Bearer Token 認證
- 新增 `ALLOWED_ORIGINS` 環境變數，可配置 CORS 允許的來源
- 新增 `/api/v1/ping` - 連線測試端點
- 新增 `/api/v1/status` - 系統狀態端點（Worker + DB）
- 新增 `/api/v1/info` - 後端資訊端點（公開）
- 新增 `/api/v1/orders` - 委託紀錄端點（使用新認證）
- 新增 `/api/v1/positions` - 持倉端點（使用新認證）

### 向下相容
- 保留原有 `X-Auth-Key` header 認證方式
- 現有端點不受影響

### 環境變數
```env
BACKEND_API_TOKEN=your_token_here
ALLOWED_ORIGINS=https://dashboard.your-saas.com,http://localhost:5173
```

## Test plan
- [ ] 測試 Bearer Token 認證
- [ ] 測試 X-Auth-Key 向下相容
- [ ] 測試 CORS 設定
- [ ] 測試 /api/v1/* 端點

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces SaaS-facing API with token-based auth and CORS, plus basic system/info endpoints.
> 
> - Adds `BACKEND_API_TOKEN` auth via `Authorization: Bearer` with fallback to `X-Auth-Key`; permits no-auth only if both unset (backward compatibility)
> - Configures CORS using `ALLOWED_ORIGINS`; parses env to set `allow_origins`
> - Sets FastAPI metadata (`title`, `description`, `version`) and exposes `VERSION = "1.1.0"`
> - New v1 endpoints: `GET /api/v1/ping` (auth), `GET /api/v1/status` (worker+DB health, auth), `GET /api/v1/info` (public backend info), `GET /api/v1/orders` (paginated orders with new auth), `GET /api/v1/positions` (positions with new auth)
> - Updates `example.env` with new variables (`BACKEND_API_TOKEN`, `ALLOWED_ORIGINS`) and structured sections; documents `SUPPORTED_FUTURES`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769bc8f7b47e60559262764ab348fff4ee8577f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->